### PR TITLE
revert: remove disable display from --prep

### DIFF
--- a/src/fxpoppet/main.py
+++ b/src/fxpoppet/main.py
@@ -106,9 +106,6 @@ def main(args: Namespace) -> int:
                 ["settings", "put", "global", "background_process_limit", "0"]
             )
             session.shell(["dumpsys", "deviceidle", "disable"])
-            # shutoff screen to prevent GPU stability related issues (emulator)
-            # surfaceflinger high CPU/hang workaround
-            session.shell(["input", "keyevent", "26"])
         if args.airplane_mode is not None:
             LOG.debug("Setting airplane mode (%d)...", args.airplane_mode)
             session.airplane_mode = args.airplane_mode == 1


### PR DESCRIPTION
Disabling the display does unfortunately prevent some issues from being triggered.